### PR TITLE
Fixed the broken link of wiki and FAQ

### DIFF
--- a/ARCHIVE/OLD-from-apache-cms/templates/sidenav.mdtext
+++ b/ARCHIVE/OLD-from-apache-cms/templates/sidenav.mdtext
@@ -6,8 +6,8 @@
 [Tutorials & How-Tos](/documentation/tutorials-how-tos.html)   
 [Configuration](/documentation/configuration.html)   
 
-[Wiki](http://s.apache.org/sling.wiki)   
-[FAQ](http://s.apache.org/sling.faq)   
+[Wiki](http://cwiki.apache.org/confluence/display/SLING)
+[FAQ](http://cwiki.apache.org/confluence/display/SLING/FAQ)
 
 **API Docs**    
 [Sling 9](/apidocs/sling9/index.html)   

--- a/src/main/jbake/assets/.htaccess
+++ b/src/main/jbake/assets/.htaccess
@@ -129,7 +129,7 @@ Redirect Permanent /site/usecases.html /index.html
 Redirect Permanent /site/version-policy.html /documentation/development/version-policy.html
 Redirect Permanent /site/web-console-extensions.html /documentation/bundles/web-console-extensions.html
 Redirect Permanent /site/webdav.html /documentation/development/repository-based-development.html
-Redirect Permanent /site/wiki.html http://s.apache.org/sling.wiki
+Redirect Permanent /site/wiki.html http://cwiki.apache.org/confluence/display/SLING
 Redirect Permanent /site/wrap-or-decorate-resources.html /documentation/the-sling-engine/wrap-or-decorate-resources.html
 Redirect Permanent /site/xslt-processing-pipeline.html /old-stuff/scriptengineintegration/xslt-processing-pipeline.html
 Redirect Permanent /javadoc-io.html /documentation/apidocs.html

--- a/src/main/jbake/templates/menu.tpl
+++ b/src/main/jbake/templates/menu.tpl
@@ -27,8 +27,8 @@ nav(class:"menu"){
         li(){
             strong("Support")
             ul() {
-                li(){a(href:"https://s.apache.org/sling.wiki", "Wiki")}
-                li(){a(href:"https://s.apache.org/sling.faq", "FAQ")}
+                li(){a(href:"https://cwiki.apache.org/confluence/display/SLING", "Wiki")}
+                li(){a(href:"https://cwiki.apache.org/confluence/display/SLING/FAQ", "FAQ")}
                 li(){a(href:"${config.site_contextPath}sitemap.html", "Site Map")}
             }
         }


### PR DESCRIPTION
Used the actual URLs instead of shortening URL, because the previous shortening URL is broken, thus it's better to use actual one.