### PR TITLE
SLING-8686: Documentation code variable name wrong

### DIFF
--- a/src/main/jbake/content/documentation/the-sling-engine/sling-api-crud-support.md
+++ b/src/main/jbake/content/documentation/the-sling-engine/sling-api-crud-support.md
@@ -37,7 +37,7 @@ Update /myresource, setting the title and body:
 **Sling API CRUD**
 
     Resource myResource = resourceResolver.getResource("/myresource");
-    ModifiableValueMap properties = myNode.adaptTo(ModifiableValueMap.class);
+    ModifiableValueMap properties = myResource.adaptTo(ModifiableValueMap.class);
     properties.put("title", {TITLE});
     properties.put("body", {BODY});
     resourceResolver.commit();


### PR DESCRIPTION
Documentation code variable name wrong in Sling API CRUD code example