### PR TITLE
Horizonal scrolling is very common throughout Sling Site docs, and it…

### DIFF
--- a/src/main/jbake/assets/res/css/site.css
+++ b/src/main/jbake/assets/res/css/site.css
@@ -48,6 +48,7 @@ a:hover {
 
 .main {
     border-top: 10px solid #cde0ea;
+    max-width: 1000px;
 }
 
 

--- a/src/main/jbake/content/documentation/development/release-management.md
+++ b/src/main/jbake/content/documentation/development/release-management.md
@@ -266,7 +266,10 @@ releases which are just announced on our [news](/news.html) page.
     
     The Apache Sling team is pleased to announce the release of Apache Sling ABC version X.Y.Z
     
-    Apache Sling is a web framework that uses a Java Content Repository, such as Apache Jackrabbit, to store and manage content. Sling applications use either scripts or Java servlets, selected based on simple name conventions, to process HTTP requests in a RESTful way.
+    Apache Sling is a web framework that uses a Java Content Repository, such as Apache 
+    Jackrabbit, to store and manage content.  Sling applications use either scripts or 
+    Java servlets, selected based on simple name conventions, to process HTTP requests 
+    in a RESTful way.
     
     <<insert short description of the sub-project>>
     


### PR DESCRIPTION
… is annoying. This page /documentation/development/release-management.html div.column.main was 2333px wide. This is caused by absence of line-breaks inside `<pre>` text and absence of max-width CSS applied to the parent .main css class. This commit sets max-width at 1000px for the .main element. If `<pre>` text extend beyond that, there will be local horizontal scroll. Therefore excessivly long `<pre>` text won't ruin the experience throughout the page. Added line breaks in the example email announcemenbt `<pre>` text also makes it more readable.