### PR TITLE
SLING-12038 add documentation for OSGi Mocks Config Annotations

### DIFF
--- a/src/main/jbake/content/documentation/development/osgi-mock.md
+++ b/src/main/jbake/content/documentation/development/osgi-mock.md
@@ -355,16 +355,16 @@ Directly use the annotation on the test method, but use the `@AutoConfig(MyServi
         assertEquals("/apps", myService.getPath());
     }
 
-To create more than one configurable service in your test, use the `@ConfigMapParameter` annotation on a `Map<String, Object>` parameters to have the typed config annotations converted for use as Map arguments to `registerInjectActivateService`:
+To create more than one configurable service in your test, use the `@ConfigMap` annotation on a `Map<String, Object>` parameters to have the typed config annotations converted for use as Map arguments to `registerInjectActivateService`:
 
     #!java
 
     @Test
     @MyServiceDependency.Config(allowedPaths = "/apps")
     @MyService.Config(path = "/apps")
-    void getPath(@ConfigMapParameter(MyServiceDependency.Config.class) 
+    void getPath(@ConfigMap(MyServiceDependency.Config.class) 
                  Map<String, Object> myDependencyConfig,
-                 @ConfigMapParameter(MyService.Config.class) 
+                 @ConfigMap(MyService.Config.class) 
                  Map<String, Object> myServiceConfig) {
         MyServiceDependency myDependency = 
             context.registerInjectActivateService(MyServiceDependency.class, myDependencyConfig);

--- a/src/main/jbake/content/documentation/development/osgi-mock.md
+++ b/src/main/jbake/content/documentation/development/osgi-mock.md
@@ -57,7 +57,7 @@ Since osgi-mock 2.0.0:
 
 Since osgi-mock 3.4.0:
 
-* Support direct construction of component property type [("Config") annotations][config-annotations].
+* Support direct construction of component property type [Config Annotations](#config-annotations).
 
 
 ## Usage


### PR DESCRIPTION
this is documentation for features introduced by https://github.com/apache/sling-org-apache-sling-testing-osgi-mock/pull/31