### PR TITLE
SLING-12278 sling-mock/osgi-mock Documentation: Clarify not to use @BeforeAll and not to instantiate context within @BeforeEach methods

### DIFF
--- a/src/main/jbake/content/documentation/development/osgi-mock.md
+++ b/src/main/jbake/content/documentation/development/osgi-mock.md
@@ -103,6 +103,7 @@ Example:
 It is possible to combine such a unit test with a `@ExtendWith` annotation e.g. for
 [Mockito JUnit Jupiter Extension][mockito-junit5-extension].
 
+The OsgiContext has to be defined as non-static field in combination with `@BeforeEach` and `@AfterEach` methods if you want to execute setup or tear down code for each test run. It is not supported to use a static field with `@BeforeAll` and `@AfterAll` methods. You should never try to instantiate a OsgiContext object within a `@BeforeEach` method, this may lead to duplicate context instances.
 
 ### JUnit 4: OSGi Context JUnit Rule
 

--- a/src/main/jbake/content/documentation/development/sling-mock.md
+++ b/src/main/jbake/content/documentation/development/sling-mock.md
@@ -116,6 +116,7 @@ Example:
 It is possible to combine such a unit test with a `@ExtendWith` annotation e.g. for
 [Mockito JUnit Jupiter Extension][mockito-junit5-extension].
 
+The SlingContext has to be defined as non-static field in combination with `@BeforeEach` and `@AfterEach` methods if you want to execute setup or tear down code for each test run. It is not supported to use a static field with `@BeforeAll` and `@AfterAll` methods. You should never try to instantiate a SlingContext object within a `@BeforeEach` method, this may lead to duplicate context instances.
 
 ### JUnit 4: Sling Context JUnit Rule
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-12278