### PR TITLE
Add redirect /apidocs/latest/ pointing to latest apidocs

### DIFF
--- a/src/main/jbake/assets/.htaccess
+++ b/src/main/jbake/assets/.htaccess
@@ -20,6 +20,10 @@ RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [R=301,L]
 # Set UTF-8 for text/plain and text/html
 AddDefaultCharset utf-8
 
+# Redirect to API docs of latest sling release
+RewriteCond %{REQUEST_URI} ^/apidocs/latest/?$
+RewriteRule ^ /apidocs/sling12/ [R=302,L]
+
 # Error pages
 ErrorDocument 403 /errors/403.html
 ErrorDocument 404 /errors/404.html


### PR DESCRIPTION
Using a temporary 302 redirect, as the links changes every few months (or years)

Redirect links:
* https://sling.apache.org/apidocs/latest -> https://sling.apache.org/apidocs/sling12/
* https://sling.apache.org/apidocs/latest/ -> https://sling.apache.org/apidocs/sling12/