### PR TITLE
rendering consistency across pages with updated ASF logos

### DIFF
--- a/src/main/jbake/assets/res/css/site.css
+++ b/src/main/jbake/assets/res/css/site.css
@@ -48,7 +48,11 @@ a:hover {
 
 .main {
     border-top: var(--page-border-top-height,10px)  solid #cde0ea;
-    max-width: 1000px;
+    overflow-x: auto;
+}
+
+.section {
+    max-width: 80%;
 }
 
 

--- a/src/main/jbake/content/documentation/development/release-management.md
+++ b/src/main/jbake/content/documentation/development/release-management.md
@@ -219,13 +219,13 @@ For the last two tasks, it's better to give the CDN some time to process the upl
 
 ### Quick update of artifacts in dist
 
-It is possible to update the artifacts without needing to checkout or update the full dist folder, which can be quite slow, by using `svn import` and `svn delete` on the remote SVN repository.
+It is possible to update the artifacts without needing to checkout or update the full dist folder, which can be quite slow.
 
 Assuming that we are releasing `org.apache.sling.engine 2.6.22` and the old version artifact names start with `org.apache.sling.engine-2.6.20`, we can run the following commands
 
     $ cd <folder where 2.6.22 is found>
-    $ svn import -m "Release org.apache.sling.engine-2.6.22" . https://dist.apache.org/repos/dist/release/sling
-    $ svn delete -m "Remove old version org.apache.sling.engine-2.6.20" $(svn ls https://dist.apache.org/repos/dist/release/sling/ | grep org.apache.sling.engine-2.6.20 | while read line; do echo "https://dist.apache.org/repos/dist/release/sling/$line"; done)
+    $ curl -fsSL https://raw.githubusercontent.com/apache/sling-tooling-release/refs/heads/master/update_dist.sh \
+            | bash -s -- org.apache.sling.engine 2.6.20 2.6.22
 
 This makes sure that the new artifacts are imported and the old ones are deleted.
 

--- a/src/main/jbake/templates/logos.tpl
+++ b/src/main/jbake/templates/logos.tpl
@@ -6,6 +6,6 @@
     }
     div(class:"header asf-logo") {
         a(href:"https://www.apache.org") {
-            img(alt:"Apache Software Foundation", src:"https://apache.org/img/asf_logo.png")
+            img(alt:"Apache Software Foundation", src:"https://apache.org/images/asflogo_horizontal_color.svg")
         }
     }

--- a/src/main/jbake/templates/menu.tpl
+++ b/src/main/jbake/templates/menu.tpl
@@ -83,7 +83,7 @@ div(class:"container") {
                     img(
                         border:"0", 
                         alt:"Support the Apache Software Foundation!", 
-                        src:"${config.site_contextPath}res/images/SupportApache-small.png",
+                        src:"https://www.apache.org/images/SupportApache-small.png",
                         width:"125"
                     )
                 }


### PR DESCRIPTION
* use the svg ASF logo
* correct the width of the main column to correctly deal with horizontal content
* updated other ASF logos to their new branding
* updated release management page with a script instead of a chain of commands

Here's the current site:
<img width="3412" height="2119" alt="Capture-2025-09-30-152411" src="https://github.com/user-attachments/assets/b3ca66bd-1c90-4241-9b75-01f4c6e1091c" />

Here's the rendering after update:
<img width="2704" height="2039" alt="Capture-2025-09-30-152320" src="https://github.com/user-attachments/assets/74876f8b-f737-4562-acd2-873da021da74" />
